### PR TITLE
Fixed capabilty secret

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,2 +1,5 @@
+import { CapSecret } from "@holochain/conductor-api"
 
 export const notImplemented = new Error("Not implemented!")
+
+export const fakeCapSecret = (): CapSecret => Buffer.from(Array(64).fill('aa').join(''), 'hex')

--- a/src/conductor.ts
+++ b/src/conductor.ts
@@ -7,6 +7,7 @@ import env from './env';
 import { connect as legacyConnect } from '@holochain/hc-web-client'
 import { AdminWebsocket, AppWebsocket } from '@holochain/conductor-api'
 import * as T from './types'
+import { fakeCapSecret } from "./common";
 
 // probably unnecessary, but it can't hurt
 // TODO: bump this gradually down to 0 until we can maybe remove it altogether
@@ -97,7 +98,7 @@ export class Conductor {
       return this.appClient!.callZome({
         cell_id: cellId as any,
         zome_name: zomeName,
-        cap: 'TODO',
+        cap: fakeCapSecret(),
         fn_name: fnName,
         payload: payload,
         provenance: 'TODO' as any

--- a/src/player.ts
+++ b/src/player.ts
@@ -84,7 +84,7 @@ export class Player {
       }
       const [_dnaHash, provenance] = cell_id
       return this.call({
-        cap: 'TODO',
+        cap: Buffer.from(Array(64).fill('aa').join(''), 'hex'),
         cell_id,
         zome_name,
         fn_name,

--- a/src/player.ts
+++ b/src/player.ts
@@ -1,13 +1,11 @@
 import * as _ from 'lodash'
 
-import { Signal, DnaId } from '@holochain/hachiko'
-
-import { Conductor, CallZomeFunc, CallAdminFunc } from './conductor'
+import { Conductor } from './conductor'
 import { Instance } from './instance'
-import { ConfigSeedArgs, SpawnConductorFn, ObjectS, ObjectN, RawConductorConfig } from './types';
+import { SpawnConductorFn, ObjectS, RawConductorConfig } from './types';
 import { makeLogger } from './logger';
 import { unparkPort } from './config/get-port-cautiously'
-import { CellId, CallZomeRequest, CapSecret, CellNick, AdminWebsocket } from '@holochain/conductor-api';
+import { CellId, CallZomeRequest, CellNick, AdminWebsocket } from '@holochain/conductor-api';
 import { unimplemented } from './util';
 import { fakeCapSecret } from './common';
 const fs = require('fs').promises

--- a/src/player.ts
+++ b/src/player.ts
@@ -7,8 +7,9 @@ import { Instance } from './instance'
 import { ConfigSeedArgs, SpawnConductorFn, ObjectS, ObjectN, RawConductorConfig } from './types';
 import { makeLogger } from './logger';
 import { unparkPort } from './config/get-port-cautiously'
-import { CellId, CallZomeRequest, CellNick, AdminWebsocket } from '@holochain/conductor-api';
+import { CellId, CallZomeRequest, CapSecret, CellNick, AdminWebsocket } from '@holochain/conductor-api';
 import { unimplemented } from './util';
+import { fakeCapSecret } from './common';
 const fs = require('fs').promises
 
 type ConstructorArgs = {
@@ -84,7 +85,7 @@ export class Player {
       }
       const [_dnaHash, provenance] = cell_id
       return this.call({
-        cap: Buffer.from(Array(64).fill('aa').join(''), 'hex'),
+        cap: fakeCapSecret(),
         cell_id,
         zome_name,
         fn_name,


### PR DESCRIPTION
See Holo-Host/holochain-conductor-api#4. This is its tryorama complement, this PR depends on the conductor api one not to break typescript types.

This is a temporary fix to get the holochain conductor to correctly deserialize the callZome arguments so that we don't have to hack our node_modules.